### PR TITLE
add m5stick-c, multiple tvs with optional soundbar

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        devices: [ 'tdisplayremote', 'fireremote', 'tdisplayt4' ]
+        devices: [ 'tdisplayremote', 'fireremote', 'tdisplayt4', 'm5stickc' ]
     steps:
       - uses: actions/checkout@v2
       - uses: esphome/build-action@v1.1.0

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ esphome-ttgo-tdisplay-s3-lvgl.yaml
 soil-sensor.yaml
 tdisplays3-switchplate.yaml
 cat-feeder.yaml
+secrets.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,17 @@ fastlane/test_output
 
 iOSInjectionProject/
 .esphome
+esphome-lvgl/LvglCheckbox.h
+esphome-lvgl/LvglComponent.h
+esphome-lvgl/LvglImage.h
+esphome-lvgl/LvglLabel.h
+esphome-lvgl/LvglSwitch.h
+esphome-lvgl/LvglToggleButton.h
+esphome-lvgl/bootlogo.h
+esphome-lvgl/lv_conf.h
+esphome-lvgl/lv_demo_conf.h
+esphome-lvgl/tftespi-component.h
+esphome-ttgo-tdisplay-s3-lvgl.yaml
+soil-sensor.yaml
+tdisplays3-switchplate.yaml
+cat-feeder.yaml

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ iPod style wifi smart home remote. Uses ESPHome and Home Assistant to integrate 
 - Scroll for volume (with scroll wheel)
 - Power, back, home, pause in second menu
 - Change source from tv source list
+- Optional soundbar support
 
 - Change current media player (tv or speaker) from home menu
 	- On boot the current media player is the first speaker found playing music or the tv
@@ -152,7 +153,4 @@ iPod style wifi smart home remote. Uses ESPHome and Home Assistant to integrate 
 - grid ui
 - circuit diagram for tdisplay
 - make sensor for current screen
-- better tv support
-	- support multiple tvs
-	- make soundbar optional
 

--- a/esphomeRemote/esphomeRemote.h
+++ b/esphomeRemote/esphomeRemote.h
@@ -226,6 +226,16 @@ int drawShuffle(int oldXPos) {
 }
 
 int drawHeaderTime(int oldXPos) {
+    switch (activeMenuState) {
+    case rootMenu:
+    case nowPlayingMenu:
+      break;
+    default:
+      if(id(my_display).get_width() < 200) {
+        return oldXPos;
+      }
+      break;
+  }
   int yPos = getHeaderTextYPos();
   std::string timeString = id(esptime).now().strftime("%I:%M%P");
   if(timeString.length() > 0 && timeString[0] == '0') {
@@ -653,9 +663,9 @@ bool drawOptionMenuAndStop() {
   case noOptionMenu:
     return false;
   case playingNewSourceMenu:
-    id(my_display).printf(id(my_display).get_width() / 2, 20 + id(margin_size), & id(medium_font), id(my_white), TextAlign::TOP_CENTER, "Playing...");
+    id(my_display).printf(id(my_display).get_width() / 2, id(header_height) + id(margin_size), & id(medium_font), id(my_white), TextAlign::TOP_CENTER, "Playing...");
     auto playingNewSourceWrappedText = getWrappedTitles(id(my_display).get_width() / 2, id(large_font_size), TextAlign::TOP_CENTER, playingNewSourceText);
-    drawTextWrapped(id(my_display).get_width() / 2, 40, 24, & id(large_font), id(my_white), TextAlign::TOP_CENTER, playingNewSourceWrappedText, 0);
+    drawTextWrapped(id(my_display).get_width() / 2, id(header_height) + id(margin_size) * 2 + id(medium_font_size), 24, & id(large_font), id(my_white), TextAlign::TOP_CENTER, playingNewSourceWrappedText, 0);
     return true;
   }
   return true;
@@ -837,17 +847,20 @@ void drawMenu() {
 }
 
 void selectMediaPlayers() {
-  if(activeMenuTitle.entityId == speakerGroup->tv->entityId) {
-    speakerGroup->activePlayer = speakerGroup->tv;
-  } else {
-    for (auto & speaker: speakerGroup->speakers) {
-      if(speaker->entityId == activeMenuTitle.entityId) {
-        speakerGroup->activePlayer = speaker;
-        break;
-      }
+  for (auto & speaker: speakerGroup->speakers) {
+    if(speaker->entityId == activeMenuTitle.entityId) {
+      speakerGroup->activePlayer = speaker;
+      topMenu();
+      return;
     }
   }
-  topMenu();
+  for (auto & tv: speakerGroup->tvs) {
+    if(tv->entityId == activeMenuTitle.entityId) {
+      speakerGroup->activePlayer = tv;
+      topMenu();
+      return;
+    }
+  }
 }
 
 bool selectRootMenu() {

--- a/esphomeRemote/esphomeRemote2Button.h
+++ b/esphomeRemote/esphomeRemote2Button.h
@@ -1,8 +1,8 @@
 #include "esphomeRemote.h"
 #include "esphomeRemoteNowPlayingMenu.h"
 
-#ifndef REMOTETHREEBUTTON
-#define REMOTETHREEBUTTON
+#ifndef REMOTETWOBUTTON
+#define REMOTETWOBUTTON
 
 void buttonPressSelect() {
   resetMarquee();
@@ -27,22 +27,6 @@ void buttonPressSelect() {
   }
 }
 
-void buttonPressLeft() {
-  resetMarquee();
-  optionMenu = noOptionMenu;
-  if (buttonPressWakeUpDisplay()) {
-    return;
-  }
-  if (menuIndex > 0) {
-    menuIndex--;
-  } else if(activeMenuState == nowPlayingMenu) {
-    menuIndex = activeMenuTitleCount - 1;
-  } else {
-    topMenu();
-  }
-  displayUpdate.updateDisplay(true);
-}
-
 void buttonPressRight() {
   resetMarquee();
   optionMenu = noOptionMenu;
@@ -52,7 +36,7 @@ void buttonPressRight() {
   if (menuIndex < activeMenuTitleCount - 1) {
     menuIndex++;
   } else if (menuIndex == activeMenuTitleCount - 1) {
-    menuIndex = 0;
+    topMenu();
   } else {
     menuIndex = 0;
   }

--- a/esphomeRemote/esphomeRemoteNowPlayingMenu.h
+++ b/esphomeRemote/esphomeRemoteNowPlayingMenu.h
@@ -1,0 +1,45 @@
+#include "esphomeRemote.h"
+
+#ifndef NOWPLAYINGMENU
+#define NOWPLAYINGMENU
+
+void selectNowPlayingMenu() {
+  if(activeMenuTitleCount <= 0 && menuIndex < activeMenuTitleCount) {
+    return;
+  }
+  auto menuTitle = getNowPlayingMenuStates()[menuIndex];
+  switch(menuTitle) {
+  case pauseNowPlayingMenuState:
+    speakerGroup -> activePlayer -> playPause();
+    break;
+  case volumeUpNowPlayingMenuState:
+    speakerGroup -> increaseSpeakerVolume();
+    optionMenu = volumeOptionMenu;
+    break;
+  case volumeDownNowPlayingMenuState:
+    speakerGroup -> decreaseSpeakerVolume();
+    optionMenu = volumeOptionMenu;
+    break;
+  case nextNowPlayingMenuState:
+    speakerGroup -> activePlayer -> nextTrack();
+    break;
+  case shuffleNowPlayingMenuState:
+    speakerGroup -> toggleShuffle();
+    break;
+  case menuNowPlayingMenuState:
+    topMenu();
+    break;
+  case TVPowerNowPlayingMenuState:
+    speakerGroup->sendActivePlayerRemoteCommand("power");
+    break;
+  case backNowPlayingMenuState:
+    speakerGroup->sendActivePlayerRemoteCommand("back");
+    break;
+  case homeNowPlayingMenuState:
+    speakerGroup->sendActivePlayerRemoteCommand("menu");
+    break;
+  }
+  displayUpdate.updateDisplay(true);
+}
+
+#endif

--- a/esphomeRemote/esphomeRemotePlayer.h
+++ b/esphomeRemote/esphomeRemotePlayer.h
@@ -789,6 +789,9 @@ class SonosSpeakerGroupComponent : public CustomAPIDevice, public Component {
   }
 
   bool updateMediaPosition() {
+    if(!playerSearchFinished) {
+      return false;
+    }
     bool updateDisplay = false;
     for (auto &speaker: speakers) {
       if (
@@ -801,12 +804,14 @@ class SonosSpeakerGroupComponent : public CustomAPIDevice, public Component {
         updateDisplay = true;
       }
     }
-    switch (activePlayer->playerType) {
-    case TVRemotePlayerType:
-      updateDisplay = false;
-      break;
-    case SpeakerRemotePlayerType:
-      break;
+    if(activePlayer != NULL) {
+      switch (activePlayer->playerType) {
+      case TVRemotePlayerType:
+        updateDisplay = false;
+        break;
+      case SpeakerRemotePlayerType:
+        break;
+      }
     }
     return updateDisplay;
   }

--- a/esphomeRemote/esphomeRemoteRotary.h
+++ b/esphomeRemote/esphomeRemoteRotary.h
@@ -18,14 +18,14 @@ void buttonPressSelect() {
   case nowPlayingMenu:
     if (optionMenu == tvOptionMenu) {
       optionMenu = noOptionMenu;
-      speakerGroup -> tv -> tvRemoteCommand("power");
+      speakerGroup->sendActivePlayerRemoteCommand("power");
       displayUpdate.updateDisplay(true);
       return;
     }
 
     switch (speakerGroup -> activePlayer -> playerType) {
     case TVRemotePlayerType:
-      speakerGroup -> tv -> tvRemoteCommand("select");
+      speakerGroup->sendActivePlayerRemoteCommand("select");
       break;
     case SpeakerRemotePlayerType:
       break;
@@ -89,7 +89,7 @@ void buttonPressUp() {
 
     switch (speakerGroup -> activePlayer -> playerType) {
     case TVRemotePlayerType:
-      speakerGroup -> tv -> tvRemoteCommand("up");
+      speakerGroup->sendActivePlayerRemoteCommand("up");
       return;
     case SpeakerRemotePlayerType:
       break;
@@ -128,14 +128,14 @@ void buttonPressDown() {
   case nowPlayingMenu:
     if (optionMenu == tvOptionMenu) {
       optionMenu = noOptionMenu;
-      speakerGroup -> tv -> tvRemoteCommand("play");
+      speakerGroup->sendActivePlayerRemoteCommand("play");
       displayUpdate.updateDisplay(true);
       return;
     }
 
     switch (speakerGroup -> activePlayer -> playerType) {
     case TVRemotePlayerType:
-      speakerGroup -> tv -> tvRemoteCommand("down");
+      speakerGroup->sendActivePlayerRemoteCommand("down");
       break;
     case SpeakerRemotePlayerType:
       if (optionMenu == speakerOptionMenu) {
@@ -161,14 +161,14 @@ void buttonPressLeft() {
   case nowPlayingMenu:
     if (optionMenu == tvOptionMenu) {
       optionMenu = noOptionMenu;
-      speakerGroup -> tv -> tvRemoteCommand("back");
+      speakerGroup->sendActivePlayerRemoteCommand("back");
       displayUpdate.updateDisplay(true);
       return;
     }
 
     switch (speakerGroup -> activePlayer -> playerType) {
     case TVRemotePlayerType:
-      speakerGroup -> tv -> tvRemoteCommand("left");
+      speakerGroup->sendActivePlayerRemoteCommand("left");
       break;
     case SpeakerRemotePlayerType:
       optionMenu = noOptionMenu;
@@ -189,13 +189,13 @@ void buttonPressRight() {
   case nowPlayingMenu:
     if (optionMenu == tvOptionMenu) {
       optionMenu = noOptionMenu;
-      speakerGroup -> tv -> tvRemoteCommand("menu");
+      speakerGroup->sendActivePlayerRemoteCommand("menu");
       displayUpdate.updateDisplay(true);
       return;
     }
     switch (speakerGroup -> activePlayer -> playerType) {
     case TVRemotePlayerType:
-      speakerGroup -> tv -> tvRemoteCommand("right");
+      speakerGroup->sendActivePlayerRemoteCommand("right");
       break;
     case SpeakerRemotePlayerType:
       if (optionMenu == speakerOptionMenu) {

--- a/esphomeRemote/sharedRemoteConfig.yaml
+++ b/esphomeRemote/sharedRemoteConfig.yaml
@@ -1,17 +1,26 @@
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-  fast_connect: true
-
-  # Enable fallback hotspot (captive portal) in case wifi connection fails
-  ap:
-    ssid: "ESPHome Remote Fallback"
-    password: !secret wifi_fallback_password
-
-# Enable logging
 logger:
 
+api:
+  services:
+    - service: goto_screen
+      variables:
+        screen_name: string
+      then:
+      - lambda: |-
+          goToScreenFromString(screen_name);
+
 ota:
+
+wifi:
+  ssid: ${wifi_ssid}
+  password: ${wifi_password}
+  fast_connect: true
+
+  ap:
+    ssid: "${friendly_name} Fallback Hotspot"
+    password: ${wifi_fallback_password}
+
+captive_portal:
 
 color:
   - id: my_red
@@ -212,17 +221,8 @@ deep_sleep:
 
 binary_sensor:
   - platform: status
-    name: ${boot_name}Node Status"
+    name: "${boot_name} Node Status"
     id: system_status
-
-api:
-  services:
-    - service: goto_screen
-      variables:
-        screen_name: string
-      then:
-      - lambda: |-
-          goToScreenFromString(screen_name);
 
 time:
   - platform: homeassistant

--- a/fireremote.yaml
+++ b/fireremote.yaml
@@ -17,7 +17,10 @@ esphome:
 
 substitutions:
   boot_name: '"Fire Remote <3"'
-  friendly_name: "Fire Remote"
+  friendly_name: "M5Fire Remote"
+  wifi_ssid: !secret wifi_ssid
+  wifi_password: !secret wifi_password
+  wifi_fallback_password: !secret wifi_fallback_password
   large_font_size: "24"
   medium_font_size: "20"
   small_font_size: "18"
@@ -31,7 +34,7 @@ substitutions:
   draw_volume_level: "false"
   draw_shuffle_disabled: "false"
 
-<<: !include sharedRemoteConfig.yaml
+<<: !include esphomeRemote/sharedRemoteConfig.yaml
 
 external_components:
   - source:

--- a/fireremote.yaml
+++ b/fireremote.yaml
@@ -11,11 +11,13 @@ esphome:
     - esphomeRemote/esphomeRemoteSensor.h
     - esphomeRemote/DisplayUpdateInterface.h
     - esphomeRemote/esphomeRemote.h
+    - esphomeRemote/esphomeRemoteNowPlayingMenu.h
     - esphomeRemote/esphomeRemote3Button.h
     - esphomeRemote/esphomeRemoteFireLight.h
 
 substitutions:
   boot_name: '"Fire Remote <3"'
+  friendly_name: "Fire Remote"
   large_font_size: "24"
   medium_font_size: "20"
   small_font_size: "18"
@@ -29,7 +31,7 @@ substitutions:
   draw_volume_level: "false"
   draw_shuffle_disabled: "false"
 
-<<: !include esphomeRemote/esphome-remote-base.yaml
+<<: !include sharedRemoteConfig.yaml
 
 external_components:
   - source:
@@ -44,7 +46,7 @@ i2c:
 
 ip5306:
   battery_level:
-    name: M5 Battery Percent
+    name: ${friendly_name} Battery Percent
     id: batteryPercent
     on_value :
       then:
@@ -56,6 +58,7 @@ ip5306:
             }
             previousBatteryLevel = id(batteryPercent).state;
   charger_connected:
+    internal: true
     id: connected
     on_press:
       then:
@@ -74,6 +77,7 @@ ip5306:
             }
   charge_full:
     id: full
+    internal: true
     on_press:
       then:
         - lambda: ESP_LOGD("TEST", "fully charged");
@@ -81,85 +85,10 @@ ip5306:
       then:
         - lambda: ESP_LOGD("TEST", "still charging");
 
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-  fast_connect: true
-
-  # Enable fallback hotspot (captive portal) in case wifi connection fails
-  ap:
-    ssid: "ESPHome Remote Fallback Hotspot"
-    password: !secret wifi_password
-
-captive_portal:
-
-# Enable logging
-logger:
-  level: INFO
-
-ota:
-
 deep_sleep:
   id: deep_sleep_fire
   wakeup_pin: 39
   wakeup_pin_mode: INVERT_WAKEUP
-
-custom_component:
-## Home assistant speakers and tv. Set TV up with a sound bar
-- lambda: |-
-    std::vector<std::string> speakerNames { 
-      "media_player.beam", 
-      "media_player.kitchen", 
-      "media_player.bedroom"
-    };
-    TVSetup tvSetup = TVSetup("media_player.55_tcl_roku_tv", "media_player.beam");
-    speakerGroup->setup(speakerNames, tvSetup);
-    App.register_component(speakerGroup);
-    return {speakerGroup};
-  id: speaker_group_component
-  
-## Home assistant scripts and scenes. Set with a friendly name
-- lambda: |-
-    std::vector<BaseService> scenes { 
-      ScriptService("script.colors", "Colors"), 
-      ScriptService("script.warm", "Warm"), 
-      ScriptService("script.dim_scene_script", "Dim"),
-      ScriptService("script.off_script", "Lights Off"),
-      SceneService("scene.hell", "Hell"),
-      ScriptService("script.feed_cat_single", "Feed cat")
-    };
-    sceneGroup->setup(scenes);
-    App.register_component(sceneGroup);
-    return {sceneGroup};
-  id: scene_group_component
-
-## Home assistant lights. Set with a friendly name
-- lambda: |-
-    std::vector<FriendlyNameEntity> lights { 
-      FriendlyNameEntity("light.bathroom_lights", "Bathroom"), 
-      FriendlyNameEntity("light.bedroom_lights", "Bedroom"), 
-      FriendlyNameEntity("light.kitchen_lights", "Kitchen"), 
-      FriendlyNameEntity("light.living_room_lights", "Living Room"), 
-      FriendlyNameEntity("light.office_lamp", "Office Lamp")
-    };
-    lightGroup->setup(lights);
-    App.register_component(lightGroup);
-    return {lightGroup};
-  id: light_group_component
-
-## Home assistant sensors. Set with a friendly name
-- lambda: |-
-    std::vector<FriendlyNameEntity> sensors { 
-      FriendlyNameEntity("sensor.vancouver_forecast", ""),
-      FriendlyNameEntity("sensor.accuweather_realfeel_temperature", "Temperature"),
-      FriendlyNameEntity("sensor.washing_machine_state", "Washing Machine"),
-      FriendlyNameEntity("sensor.soil_sensor_soil_moisture_2", "Plant Moisture"),
-      FriendlyNameEntity("sensor.particulate_matter_2_5um_concentration", "Kitchen Air")
-    };
-    sensorGroup->setup(sensors);
-    App.register_component(sensorGroup);
-    return {sensorGroup};
-  id: sensor_group_component
 
 binary_sensor:
   - platform: gpio
@@ -193,7 +122,7 @@ binary_sensor:
 # We can still control the backlight independently
 switch:
   - platform: template
-    name: M5Stack Fire Sleep Toggle
+    name: ${friendly_name} Sleep Toggle
     id: sleep_toggle
     optimistic: true
     on_turn_on:
@@ -202,7 +131,7 @@ switch:
             id: deep_sleep_fire
   - platform: gpio
     pin: 32
-    name: "Backlight"
+    name: ${friendly_name} Backlight
     id: backlight
     restore_mode: ALWAYS_ON
     internal: true
@@ -214,7 +143,7 @@ light:
     num_leds: 10
     rgb_order: GRB
     id: side_light
-    name: "Remote Light"
+    name: ${friendly_name} Remote Light"
     restore_mode: ALWAYS_OFF
     default_transition_length: 0s
     effects:

--- a/m5stickc.yaml
+++ b/m5stickc.yaml
@@ -20,6 +20,9 @@ esp32:
 substitutions:
   boot_name: '"M5Stick Remote <3"'
   friendly_name: M5stickcRemote
+  wifi_ssid: !secret wifi_ssid
+  wifi_password: !secret wifi_password
+  wifi_fallback_password: !secret wifi_fallback_password
   large_font_size: "20"
   medium_font_size: "14"
   small_font_size: "12"
@@ -33,7 +36,7 @@ substitutions:
   draw_volume_level: "false"
   draw_shuffle_disabled: "false"
 
-<<: !include sharedRemoteConfig.yaml
+<<: !include esphomeRemote/sharedRemoteConfig.yaml
 
 i2c:
    - id: bus_a
@@ -73,13 +76,13 @@ sensor:
 light:
   - platform: monochromatic
     output:  builtin_led
-    name: ${friendly_name} Led
+    name: Led
     id: led1
   - platform: axp192
     id: axpbacklight
     axp192_id: axp
     restore_mode: ALWAYS_ON
-    name: ${friendly_name} Backlight
+    name: Backlight
 
 output:
   - platform: ledc
@@ -92,7 +95,7 @@ binary_sensor:
     axp192_id: axp
     type: charging
     id: axp_charger
-    name: ${friendly_name} Charger
+    name: Charger
     on_state:
       then:
         lambda: |-
@@ -101,7 +104,7 @@ binary_sensor:
     pin:
       number: GPIO37
       inverted: true
-    name: ${friendly_name} Button A
+    name: Button A
     on_press:
       then:
         lambda: |-
@@ -117,7 +120,7 @@ binary_sensor:
     pin:
       number: GPIO39
       inverted: true
-    name: ${friendly_name} Button B
+    name: Button B
     on_press:
       then:
         lambda: |-
@@ -164,9 +167,9 @@ display:
     lambda: |-
       if (idleTime < 0) {
         ESP_LOGD("drawing menu", "turning on");
-      //  id(backlight).turn_on();
+        id(backlight).turn_on();
         idleTime = 0;
       }
 
-      // drawMenu();
+      drawMenu();
       return;

--- a/m5stickc.yaml
+++ b/m5stickc.yaml
@@ -13,13 +13,13 @@ esphome:
     - esphomeRemote/esphomeRemote2Button.h
 
 esp32:
-  board: esp32dev
+  board: m5stick-c
   framework:
     type: arduino
 
 substitutions:
   boot_name: '"M5Stick Remote <3"'
-  friendly_name: '"M5stickcRemote"'
+  friendly_name: M5stickcRemote
   large_font_size: "20"
   medium_font_size: "14"
   small_font_size: "12"
@@ -73,13 +73,13 @@ sensor:
 light:
   - platform: monochromatic
     output:  builtin_led
-    name: "${friendly_name} Led"
+    name: ${friendly_name} Led
     id: led1
   - platform: axp192
     id: axpbacklight
     axp192_id: axp
     restore_mode: ALWAYS_ON
-    name: "${friendly_name} Backlight"
+    name: ${friendly_name} Backlight
 
 output:
   - platform: ledc
@@ -92,7 +92,7 @@ binary_sensor:
     axp192_id: axp
     type: charging
     id: axp_charger
-    name: "${friendly_name} Charger"
+    name: ${friendly_name} Charger
     on_state:
       then:
         lambda: |-

--- a/m5stickc.yaml
+++ b/m5stickc.yaml
@@ -1,0 +1,172 @@
+esphome:
+  name: m5stickc
+  includes:
+    - esphomeRemote/MenuGlobals.h
+    - esphomeRemote/MenuTitle.h
+    - esphomeRemote/esphomeRemotePlayer.h
+    - esphomeRemote/esphomeRemoteService.h
+    - esphomeRemote/esphomeRemoteLight.h
+    - esphomeRemote/esphomeRemoteSensor.h
+    - esphomeRemote/DisplayUpdateInterface.h
+    - esphomeRemote/esphomeRemote.h
+    - esphomeRemote/esphomeRemoteNowPlayingMenu.h
+    - esphomeRemote/esphomeRemote2Button.h
+
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+
+substitutions:
+  boot_name: '"M5Stick Remote <3"'
+  friendly_name: '"M5stickcRemote"'
+  large_font_size: "20"
+  medium_font_size: "14"
+  small_font_size: "12"
+  header_height: "16"
+  margin_size: "4"
+  scroll_bar_width: "6"
+  bottom_bar_margin: "32"
+  now_playing_max_lines: "5"
+  draw_now_playing_menu: "true"
+  draw_battery_level: "true"
+  draw_volume_level: "false"
+  draw_shuffle_disabled: "false"
+
+<<: !include sharedRemoteConfig.yaml
+
+i2c:
+   - id: bus_a
+     sda: GPIO21
+     scl: GPIO22
+     scan: true
+
+external_components:
+  - source:
+      type: git
+      url: https://gitlab.com/geiseri/esphome_extras.git
+    refresh: 0s
+    components: [axp192]
+
+axp192:
+  id: axp
+  address: 0x34
+  i2c_id: bus_a
+  update_interval: 60s
+
+sensor:
+    # AXP192 power management - must be present to initialize TFT power on
+  - platform: axp192
+    axp192_id: axp
+    id: batteryPercent
+  - platform: template
+    id: display_update_tick
+    filters:
+      - debounce: 0.02s
+    on_value :
+      then:
+        - lambda: |-
+            if(idleTime < 2) {
+              displayUpdate.updateDisplay(true);
+            }
+# internal LED
+light:
+  - platform: monochromatic
+    output:  builtin_led
+    name: "${friendly_name} Led"
+    id: led1
+  - platform: axp192
+    id: axpbacklight
+    axp192_id: axp
+    restore_mode: ALWAYS_ON
+    name: "${friendly_name} Backlight"
+
+output:
+  - platform: ledc
+    pin: 10
+    inverted: true
+    id: builtin_led
+
+binary_sensor:
+  - platform: axp192
+    axp192_id: axp
+    type: charging
+    id: axp_charger
+    name: "${friendly_name} Charger"
+    on_state:
+      then:
+        lambda: |-
+          charging = x;
+  - platform: gpio
+    pin:
+      number: GPIO37
+      inverted: true
+    name: ${friendly_name} Button A
+    on_press:
+      then:
+        lambda: |-
+            buttonPressRight();
+            auto call = id(led1).turn_on();
+            call.set_transition_length(0);
+            call.perform();
+    on_release:
+      then:
+        - light.turn_off: led1
+        
+  - platform: gpio
+    pin:
+      number: GPIO39
+      inverted: true
+    name: ${friendly_name} Button B
+    on_press:
+      then:
+        lambda: |-
+            buttonPressSelect();
+            auto call = id(led1).turn_on();
+            call.set_transition_length(0);
+            call.perform();
+    on_release:
+      then:
+        - light.turn_off: led1
+
+switch:
+  - platform: template
+    id: sleep_toggle
+    internal: true
+    optimistic: true
+  - platform: template
+    id: backlight
+    optimistic: true
+    internal: true
+    on_turn_on:
+      then:
+        - light.turn_on:
+            id: axpbacklight
+    on_turn_off:
+      then:
+        - light.turn_off:
+            id: axpbacklight
+            transition_length: 0.5s
+
+spi:
+  clk_pin: GPIO13
+  mosi_pin: GPIO15
+
+display:
+  - platform: st7789v
+    model: TTGO_TDisplay_135x240
+    id: my_display
+    cs_pin: GPIO5
+    dc_pin: GPIO23
+    reset_pin: GPIO18
+    rotation: 0
+    update_interval: 60s
+    lambda: |-
+      if (idleTime < 0) {
+        ESP_LOGD("drawing menu", "turning on");
+      //  id(backlight).turn_on();
+        idleTime = 0;
+      }
+
+      // drawMenu();
+      return;

--- a/secrets.yaml
+++ b/secrets.yaml
@@ -2,5 +2,6 @@
 wifi_bssid: "1C:87:2C:70:C2:C2"
 wifi_ssid: "ssid"
 wifi_password: "wifipass"
+wifi_fallback_password: "wififallbackpass"
 api_encryption: "apiencryption"
 ota_encryption: "otaencryption"

--- a/sharedRemoteConfig.yaml
+++ b/sharedRemoteConfig.yaml
@@ -1,13 +1,12 @@
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  fast_connect: true
 
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
     ssid: "ESPHome Remote Fallback"
-    password: !secret wifi_password
-
-captive_portal:
+    password: !secret wifi_fallback_password
 
 # Enable logging
 logger:
@@ -229,64 +228,64 @@ time:
   - platform: homeassistant
     id: esptime
 
-#custom_component:
-## Home assistant speakers and tv. Set TV up with a sound bar
-# - lambda: |-
-#     SpeakerSetup soundBar = SpeakerSetup("media_player.beam", "Beam");
-#     std::vector<TVSetup> tvSetup = {
-#       TVSetup("media_player.55_tcl_roku_tv", "TV", 
-#         &soundBar
-#       ),
-#       TVSetup("media_player.55_tcl_roku_tv", "Fake", NULL)
-#     };
-#     std::vector<SpeakerSetup> speakerSetup = {
-#       SpeakerSetup("media_player.kitchen", "Kitchen"),
-#       SpeakerSetup("media_player.bedroom", "Bedroom")
-#     };
-#     speakerGroup->setup(tvSetup, speakerSetup);
-#     App.register_component(speakerGroup);
-#     return {speakerGroup};
-#   id: speaker_group_component
-  
-# ## Home assistant scripts and scenes. Set with a friendly name
-# - lambda: |-
-#     std::vector<BaseService> scenes { 
-#       ScriptService("script.colors", "Colors"), 
-#       ScriptService("script.warm", "Warm"), 
-#       ScriptService("script.dim_scene_script", "Dim"),
-#       ScriptService("script.off_script", "Lights Off"),
-#       SceneService("scene.hell", "Hell"),
-#       ScriptService("script.feed_cat_single", "Feed cat")
-#     };
-#     sceneGroup->setup(scenes);
-#     App.register_component(sceneGroup);
-#     return {sceneGroup};
-#   id: scene_group_component
+custom_component:
+# Home assistant speakers and tv. Set TV up with a sound bar
+ - lambda: |-
+     SpeakerSetup soundBar = SpeakerSetup("media_player.beam", "Beam");
+     std::vector<TVSetup> tvSetup = {
+       TVSetup("media_player.55_tcl_roku_tv", "TV", 
+         &soundBar
+       ),
+       TVSetup("media_player.55_tcl_roku_tv", "Fake", NULL)
+     };
+     std::vector<SpeakerSetup> speakerSetup = {
+       SpeakerSetup("media_player.kitchen", "Kitchen"),
+       SpeakerSetup("media_player.bedroom", "Bedroom")
+     };
+     speakerGroup->setup(tvSetup, speakerSetup);
+     App.register_component(speakerGroup);
+     return {speakerGroup};
+   id: speaker_group_component
+ 
+ ## Home assistant scripts and scenes. Set with a friendly name
+ - lambda: |-
+     std::vector<BaseService> scenes { 
+       ScriptService("script.colors", "Colors"), 
+       ScriptService("script.warm", "Warm"), 
+       ScriptService("script.dim_scene_script", "Dim"),
+       ScriptService("script.off_script", "Lights Off"),
+       SceneService("scene.hell", "Hell"),
+       ScriptService("script.feed_cat_single", "Feed cat")
+     };
+     sceneGroup->setup(scenes);
+     App.register_component(sceneGroup);
+     return {sceneGroup};
+   id: scene_group_component
 
-# ## Home assistant lights. Set with a friendly name
-# - lambda: |-
-#     std::vector<FriendlyNameEntity> lights { 
-#       FriendlyNameEntity("light.bathroom_lights", "Bathroom"), 
-#       FriendlyNameEntity("light.bedroom_lights", "Bedroom"), 
-#       FriendlyNameEntity("light.kitchen_lights", "Kitchen"), 
-#       FriendlyNameEntity("light.living_room_lights", "Living Room"), 
-#       FriendlyNameEntity("light.office_lamp", "Office Lamp")
-#     };
-#     lightGroup->setup(lights);
-#     App.register_component(lightGroup);
-#     return {lightGroup};
-#   id: light_group_component
+ ## Home assistant lights. Set with a friendly name
+ - lambda: |-
+     std::vector<FriendlyNameEntity> lights { 
+       FriendlyNameEntity("light.bathroom_lights", "Bathroom"), 
+       FriendlyNameEntity("light.bedroom_lights", "Bedroom"), 
+       FriendlyNameEntity("light.kitchen_lights", "Kitchen"), 
+       FriendlyNameEntity("light.living_room_lights", "Living Room"), 
+       FriendlyNameEntity("light.office_lamp", "Office Lamp")
+     };
+     lightGroup->setup(lights);
+     App.register_component(lightGroup);
+     return {lightGroup};
+   id: light_group_component
 
-# ## Home assistant sensors. Set with a friendly name
-# - lambda: |-
-#     std::vector<FriendlyNameEntity> sensors {
-#       FriendlyNameEntity("sensor.vancouver_forecast", ""),
-#       FriendlyNameEntity("sensor.accuweather_realfeel_temperature", "Temperature"),
-#       FriendlyNameEntity("sensor.washing_machine_state", "Washing Machine"),
-#       FriendlyNameEntity("sensor.soil_sensor_soil_moisture_2", "Plant Moisture"),
-#       FriendlyNameEntity("sensor.particulate_matter_2_5um_concentration", "Kitchen Air")
-#     };
-#     sensorGroup->setup(sensors);
-#     App.register_component(sensorGroup);
-#     return {sensorGroup};
-#   id: sensor_group_component
+ ## Home assistant sensors. Set with a friendly name
+ - lambda: |-
+     std::vector<FriendlyNameEntity> sensors {
+       FriendlyNameEntity("sensor.vancouver_forecast", ""),
+       FriendlyNameEntity("sensor.accuweather_realfeel_temperature", "Temperature"),
+       FriendlyNameEntity("sensor.washing_machine_state", "Washing Machine"),
+       FriendlyNameEntity("sensor.soil_sensor_soil_moisture_2", "Plant Moisture"),
+       FriendlyNameEntity("sensor.particulate_matter_2_5um_concentration", "Kitchen Air")
+     };
+     sensorGroup->setup(sensors);
+     App.register_component(sensorGroup);
+     return {sensorGroup};
+   id: sensor_group_component

--- a/sharedRemoteConfig.yaml
+++ b/sharedRemoteConfig.yaml
@@ -1,3 +1,19 @@
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: "ESPHome Remote Fallback"
+    password: !secret wifi_password
+
+captive_portal:
+
+# Enable logging
+logger:
+
+ota:
+
 color:
   - id: my_red
     red: 100%
@@ -212,3 +228,65 @@ api:
 time:
   - platform: homeassistant
     id: esptime
+
+#custom_component:
+## Home assistant speakers and tv. Set TV up with a sound bar
+# - lambda: |-
+#     SpeakerSetup soundBar = SpeakerSetup("media_player.beam", "Beam");
+#     std::vector<TVSetup> tvSetup = {
+#       TVSetup("media_player.55_tcl_roku_tv", "TV", 
+#         &soundBar
+#       ),
+#       TVSetup("media_player.55_tcl_roku_tv", "Fake", NULL)
+#     };
+#     std::vector<SpeakerSetup> speakerSetup = {
+#       SpeakerSetup("media_player.kitchen", "Kitchen"),
+#       SpeakerSetup("media_player.bedroom", "Bedroom")
+#     };
+#     speakerGroup->setup(tvSetup, speakerSetup);
+#     App.register_component(speakerGroup);
+#     return {speakerGroup};
+#   id: speaker_group_component
+  
+# ## Home assistant scripts and scenes. Set with a friendly name
+# - lambda: |-
+#     std::vector<BaseService> scenes { 
+#       ScriptService("script.colors", "Colors"), 
+#       ScriptService("script.warm", "Warm"), 
+#       ScriptService("script.dim_scene_script", "Dim"),
+#       ScriptService("script.off_script", "Lights Off"),
+#       SceneService("scene.hell", "Hell"),
+#       ScriptService("script.feed_cat_single", "Feed cat")
+#     };
+#     sceneGroup->setup(scenes);
+#     App.register_component(sceneGroup);
+#     return {sceneGroup};
+#   id: scene_group_component
+
+# ## Home assistant lights. Set with a friendly name
+# - lambda: |-
+#     std::vector<FriendlyNameEntity> lights { 
+#       FriendlyNameEntity("light.bathroom_lights", "Bathroom"), 
+#       FriendlyNameEntity("light.bedroom_lights", "Bedroom"), 
+#       FriendlyNameEntity("light.kitchen_lights", "Kitchen"), 
+#       FriendlyNameEntity("light.living_room_lights", "Living Room"), 
+#       FriendlyNameEntity("light.office_lamp", "Office Lamp")
+#     };
+#     lightGroup->setup(lights);
+#     App.register_component(lightGroup);
+#     return {lightGroup};
+#   id: light_group_component
+
+# ## Home assistant sensors. Set with a friendly name
+# - lambda: |-
+#     std::vector<FriendlyNameEntity> sensors {
+#       FriendlyNameEntity("sensor.vancouver_forecast", ""),
+#       FriendlyNameEntity("sensor.accuweather_realfeel_temperature", "Temperature"),
+#       FriendlyNameEntity("sensor.washing_machine_state", "Washing Machine"),
+#       FriendlyNameEntity("sensor.soil_sensor_soil_moisture_2", "Plant Moisture"),
+#       FriendlyNameEntity("sensor.particulate_matter_2_5um_concentration", "Kitchen Air")
+#     };
+#     sensorGroup->setup(sensors);
+#     App.register_component(sensorGroup);
+#     return {sensorGroup};
+#   id: sensor_group_component

--- a/tdisplayremote.yaml
+++ b/tdisplayremote.yaml
@@ -13,26 +13,9 @@ esphome:
     - esphomeRemote/esphomeRemote.h
     - esphomeRemote/esphomeRemoteRotary.h
 
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-  fast_connect: true
-
-  # Enable fallback hotspot (captive portal) in case wifi connection fails
-  ap:
-    ssid: "ESPHome Remote Fallback Hotspot"
-    password: !secret wifi_password
-
-captive_portal:
-
-# Enable logging
-logger:
-  level: INFO
-
-ota:
-
 substitutions:
   boot_name: '"TDisplay Remote <3"'
+  friendly_name: "TDisplay Remote"
   large_font_size: "24"
   medium_font_size: "15"
   small_font_size: "14"
@@ -46,63 +29,7 @@ substitutions:
   draw_volume_level: "false"
   draw_shuffle_disabled: "false"
 
-<<: !include esphomeRemote/esphome-remote-base.yaml
-
-custom_component:
-## Home assistant speakers and tv. Set TV up with a sound bar
-- lambda: |-
-    std::vector<std::string> speakerNames { 
-      "media_player.beam", 
-      "media_player.kitchen", 
-      "media_player.bedroom"
-    };
-    TVSetup tvSetup = TVSetup("media_player.55_tcl_roku_tv", "media_player.beam");
-    speakerGroup->setup(speakerNames, tvSetup);
-    App.register_component(speakerGroup);
-    return {speakerGroup};
-  id: speaker_group_component
-  
-## Home assistant scripts and scenes. Set with a friendly name
-- lambda: |-
-    std::vector<BaseService> scenes { 
-      ScriptService("script.colors", "Colors"), 
-      ScriptService("script.warm", "Warm"), 
-      ScriptService("script.dim_scene_script", "Dim"),
-      ScriptService("script.off_script", "Lights Off"),
-      SceneService("scene.hell", "Hell"),
-      ScriptService("script.feed_cat_single", "Feed cat")
-    };
-    sceneGroup->setup(scenes);
-    App.register_component(sceneGroup);
-    return {sceneGroup};
-  id: scene_group_component
-
-## Home assistant lights. Set with a friendly name
-- lambda: |-
-    std::vector<FriendlyNameEntity> lights { 
-      FriendlyNameEntity("light.bathroom_lights", "Bathroom"), 
-      FriendlyNameEntity("light.bedroom_lights", "Bedroom"), 
-      FriendlyNameEntity("light.kitchen_lights", "Kitchen"), 
-      FriendlyNameEntity("light.living_room_lights", "Living Room"), 
-      FriendlyNameEntity("light.office_lamp", "Office Lamp")
-    };
-    lightGroup->setup(lights);
-    App.register_component(lightGroup);
-    return {lightGroup};
-  id: light_group_component
-
-## Home assistant sensors. Set with a friendly name
-- lambda: |-
-    std::vector<FriendlyNameEntity> sensors { 
-      FriendlyNameEntity("sensor.vancouver_forecast", ""),
-      FriendlyNameEntity("sensor.accuweather_realfeel_temperature", "Temperature"),
-      FriendlyNameEntity("sensor.washing_machine_state", "Washing Machine"),
-      FriendlyNameEntity("sensor.soil_sensor_soil_moisture_2", "Plant Moisture")
-    };
-    sensorGroup->setup(sensors);
-    App.register_component(sensorGroup);
-    return {sensorGroup};
-  id: sensor_group_component
+<<: !include sharedRemoteConfig.yaml
   
 sensor:
 ## Rotary

--- a/tdisplayremote.yaml
+++ b/tdisplayremote.yaml
@@ -16,6 +16,9 @@ esphome:
 substitutions:
   boot_name: '"TDisplay Remote <3"'
   friendly_name: "TDisplay Remote"
+  wifi_ssid: !secret wifi_ssid
+  wifi_password: !secret wifi_password
+  wifi_fallback_password: !secret wifi_fallback_password
   large_font_size: "24"
   medium_font_size: "15"
   small_font_size: "14"
@@ -29,7 +32,7 @@ substitutions:
   draw_volume_level: "false"
   draw_shuffle_disabled: "false"
 
-<<: !include sharedRemoteConfig.yaml
+<<: !include esphomeRemote/sharedRemoteConfig.yaml
   
 sensor:
 ## Rotary

--- a/tdisplayt4.yaml
+++ b/tdisplayt4.yaml
@@ -20,6 +20,9 @@ esp32:
 substitutions:
   boot_name: '"Kitchen Remote <3"'
   friendly_name: "Kitchen Remote"
+  wifi_ssid: !secret wifi_ssid
+  wifi_password: !secret wifi_password
+  wifi_fallback_password: !secret wifi_fallback_password
   large_font_size: "24"
   medium_font_size: "20"
   small_font_size: "18"
@@ -33,7 +36,7 @@ substitutions:
   draw_volume_level: "false"
   draw_shuffle_disabled: "false"
 
-<<: !include sharedRemoteConfig.yaml
+<<: !include esphomeRemote/sharedRemoteConfig.yaml
 
 sensor:
   - platform: template

--- a/tdisplayt4.yaml
+++ b/tdisplayt4.yaml
@@ -9,6 +9,7 @@ esphome:
     - esphomeRemote/esphomeRemoteSensor.h
     - esphomeRemote/DisplayUpdateInterface.h
     - esphomeRemote/esphomeRemote.h
+    - esphomeRemote/esphomeRemoteNowPlayingMenu.h
     - esphomeRemote/esphomeRemote3Button.h
 
 esp32:
@@ -16,28 +17,9 @@ esp32:
   framework:
     type: arduino
 
-# Enable logging
-logger:
-  level: INFO
-
-ota:
-  password: !secret ota_encryption
-
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-  fast_connect: true
-
-  # Enable fallback hotspot (captive portal) in case wifi connection fails
-  ap:
-    ssid: "ESPHome Remote Fallback Hotspot"
-    password: !secret wifi_password
-
-captive_portal:
-
-
 substitutions:
   boot_name: '"Kitchen Remote <3"'
+  friendly_name: "Kitchen Remote"
   large_font_size: "24"
   medium_font_size: "20"
   small_font_size: "18"
@@ -51,58 +33,8 @@ substitutions:
   draw_volume_level: "false"
   draw_shuffle_disabled: "false"
 
-<<: !include esphomeRemote/esphome-remote-base.yaml
+<<: !include sharedRemoteConfig.yaml
 
-custom_component:
-- lambda: |-
-    std::vector<std::string> speakerNames { 
-      "media_player.beam", 
-      "media_player.kitchen", 
-      "media_player.bedroom"
-    };
-    TVSetup tvSetup = TVSetup("media_player.55_tcl_roku_tv", "media_player.beam");
-    speakerGroup->setup(speakerNames, tvSetup);
-    App.register_component(speakerGroup);
-    return {speakerGroup};
-  id: speaker_group_component
-- lambda: |-
-    std::vector<BaseService> scenes { 
-      ScriptService("script.colors", "Colors"), 
-      ScriptService("script.warm", "Warm"), 
-      ScriptService("script.dim_scene_script", "Dim"),
-      ScriptService("script.off_script", "Lights Off"),
-      SceneService("scene.hell", "Hell"),
-      ScriptService("script.feed_cat_single", "Feed cat")
-    };
-    sceneGroup->setup(scenes);
-    App.register_component(sceneGroup);
-    return {sceneGroup};
-  id: scene_group_component
-- lambda: |-
-    std::vector<FriendlyNameEntity> lights { 
-      FriendlyNameEntity("light.bathroom_lights", "Bathroom"), 
-      FriendlyNameEntity("light.bedroom_lights", "Bedroom"), 
-      FriendlyNameEntity("light.kitchen_lights", "Kitchen"), 
-      FriendlyNameEntity("light.living_room_lights", "Living Room"), 
-      FriendlyNameEntity("light.office_lamp", "Office Lamp")
-    };
-    lightGroup->setup(lights);
-    App.register_component(lightGroup);
-    return {lightGroup};
-  id: light_group_component
-- lambda: |-
-    std::vector<FriendlyNameEntity> sensors { 
-      FriendlyNameEntity("sensor.vancouver_forecast", ""),
-      FriendlyNameEntity("sensor.accuweather_realfeel_temperature", "Temperature"),
-      FriendlyNameEntity("sensor.washing_machine_state", "Washing Machine"),
-      FriendlyNameEntity("sensor.soil_sensor_soil_moisture_2", "Plant Moisture"),
-      FriendlyNameEntity("sensor.particulate_matter_2_5um_concentration", "Kitchen Air")
-    };
-    sensorGroup->setup(sensors);
-    App.register_component(sensorGroup);
-    return {sensorGroup};
-  id: sensor_group_component
-  
 sensor:
   - platform: template
     id: display_update_tick


### PR DESCRIPTION
### 1. supports multiple tvs! 
this is a breaking change in the setup. the new format for tvs and speakers is like this 
```
SpeakerSetup soundBar = SpeakerSetup("media_player.beam", "Beam");
std::vector<TVSetup> tvSetup = {
 TVSetup("media_player.55_tcl_roku_tv", "TV", 
   &soundBar
 ),
 TVSetup("media_player.55_tcl_roku_tv", "Fake", NULL)
};
std::vector<SpeakerSetup> speakerSetup = {
 SpeakerSetup("media_player.kitchen", "Kitchen"),
 SpeakerSetup("media_player.bedroom", "Bedroom")
};
speakerGroup->setup(tvSetup, speakerSetup);
App.register_component(speakerGroup);
return {speakerGroup};
```
### 2. Added M5Stick-C
Battery level, charging and led support. The m5stick c only has 2 buttons so the controls are more simplified. In the future I'm going to add motion controls to extend what we can do

### 3. Fixed a bug with the UI when you pick a new source